### PR TITLE
Bump version to 2.0.0-SNAPSHOT for XP 8

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            1.x
 
   release:
     runs-on: ubuntu-latest

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,4 +11,4 @@ xpVersion = 8.0.0-B4
 # Gradle Project settings
 projectName = cty-manager
 
-version=1.1.1-SNAPSHOT
+version=2.0.0-SNAPSHOT


### PR DESCRIPTION
## Summary
- Branch out the XP 7 maintenance line (`1.x` from tag `v1.1.0`) and bump master to the next-major SNAPSHOT, following the [app-booster](https://github.com/enonic/app-booster) pattern.
- `gradle.properties`: `version` `1.1.1-SNAPSHOT` → `2.0.0-SNAPSHOT`.
- `.github/workflows/enonic-gradle.yml`: declare `master` and `1.x` as release branches so `enonic/release-tools/build-and-publish` recognizes both.

A companion PR against `1.x` adds the same `releaseBranch:` block on that branch's workflow file, which is required for the action to treat pushes to `1.x` as releases.

## Test plan
- [ ] CI: `Gradle Build` workflow runs and passes on this branch.
- [ ] Local sanity: `./gradlew clean build` is green from master after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)