### PR TITLE
Migrate to lib-asset #560

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ dependencies {
     include xplibs.content
     include xplibs.portal
     include "com.enonic.lib:lib-thymeleaf:3.0.0-SNAPSHOT"
+    include "com.enonic.lib:lib-asset:2.0.0-SNAPSHOT"
 }
 
 repositories {

--- a/src/main/resources/admin/tools/content-type-manager/content-type-manager.js
+++ b/src/main/resources/admin/tools/content-type-manager/content-type-manager.js
@@ -1,4 +1,4 @@
-const portalLib = require('/lib/xp/portal');
+const assetLib = require('/lib/enonic/asset');
 const thymeleafLib = require('/lib/thymeleaf');
 
 exports.get = () => {
@@ -6,13 +6,13 @@ exports.get = () => {
 
   const model = {
     favicon: {
-      svg: portalLib.assetUrl({ path: 'img/favicon.svg' }),
-      png: portalLib.assetUrl({ path: 'img/favicon.png' }),
+      svg: assetLib.assetUrl({ path: 'img/favicon.svg' }),
+      png: assetLib.assetUrl({ path: 'img/favicon.png' }),
     },
-    loadingIcon: portalLib.assetUrl({ path: 'img/spinning-loader.gif' }),
+    loadingIcon: assetLib.assetUrl({ path: 'img/spinning-loader.gif' }),
     scripts: {
-      vendor: portalLib.assetUrl({ path: 'js/vendor.js' }),
-      app: portalLib.assetUrl({ path: 'js/app.js' }),
+      vendor: assetLib.assetUrl({ path: 'js/vendor.js' }),
+      app: assetLib.assetUrl({ path: 'js/app.js' }),
     },
   };
 

--- a/src/main/resources/admin/tools/content-type-manager/content-type-manager.yaml
+++ b/src/main/resources/admin/tools/content-type-manager/content-type-manager.yaml
@@ -9,3 +9,4 @@ apis:
   - "admin:extension"
   - "admin:event"
   - "admin:status"
+  - "asset"


### PR DESCRIPTION
Closes #560

`portal.assetUrl` is deprecated in lib-portal (_Use libAsset or libStatic instead. This function will be removed in future versions._). The five call sites in this app are all in a single admin tool controller, so **lib-asset** is the right target — `lib-static` is reserved for admin extensions, ID providers, and Universal APIs, none of which apply here.

## Changes

- `build.gradle` — add `include "com.enonic.lib:lib-asset:2.0.0-SNAPSHOT"`.
- `src/main/resources/admin/tools/content-type-manager/content-type-manager.yaml` — register `apis: ["asset"]` on the admin tool descriptor so the Universal API is mounted on the admin tool host.
- `src/main/resources/admin/tools/content-type-manager/content-type-manager.js` — swap `require('/lib/xp/portal').assetUrl(...)` for `require('/lib/enonic/asset').assetUrl(...)` at all five call sites (favicon svg/png, loadingIcon, vendor.js, app.js). The `/lib/xp/portal` import is dropped — it was only used for `assetUrl`.

## Test plan

- [x] `./gradlew build --refresh-dependencies` clean.
- [x] Bundle reaches ACTIVE in XP 8.0.0-SNAPSHOT (`Started application com.enonic.app.cty.manager bundle 117`).
- [x] Admin tool page (`/admin/com.enonic.app.cty.manager/content-type-manager`) returns 200 and emits lib-asset URLs in the rendered HTML (`/_/com.enonic.app.cty.manager:asset/<fingerprint>/...`).
- [x] Each of the five rewritten asset URLs returns HTTP 200 with the expected content-type and non-zero bytes (svg 4996 B, png 12794 B, gif 573306 B, vendor.js 1.7 MB, app.js 1.7 MB).