### PR TITLE
Introduce TOML version catalog

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,8 +11,8 @@ dependencies {
     include xplibs.admin
     include xplibs.content
     include xplibs.portal
-    include "com.enonic.lib:lib-thymeleaf:3.0.0-SNAPSHOT"
-    include "com.enonic.lib:lib-asset:2.0.0-SNAPSHOT"
+    include libs.lib.thymeleaf
+    include libs.lib.asset
 }
 
 repositories {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,7 @@
+[versions]
+asset = "2.0.0-SNAPSHOT"
+thymeleaf = "3.0.0-SNAPSHOT"
+
+[libraries]
+lib-asset = { module = "com.enonic.lib:lib-asset", version.ref = "asset" }
+lib-thymeleaf = { module = "com.enonic.lib:lib-thymeleaf", version.ref = "thymeleaf" }


### PR DESCRIPTION
## Summary

Migrate `app-cty-manager` from inline dependency-version strings to a Gradle TOML version catalog at `gradle/libs.versions.toml`. Part of a tree-wide effort to unify the catalog/inline split across IdeaProjects repos so bulk version bumps (XP 8 SNAPSHOTs, etc.) can be a single sed sweep.

Pin-for-pin migration — no version changes, no functional behavior change.

## Conventions adopted

- `[versions]` and `[libraries]` sorted alphabetically.
- Short, lowercase, hyphen-separated keys (`lib-thymeleaf`, not `libThymeleaf` or `lib_thymeleaf`).
- `xpVersion` remains in `gradle.properties` (rest of the toolchain expects it there); `com.enonic.xp:*` lines that consume `${xpVersion}` are untouched.
- `xplibs.*` accessors untouched — those come from the `com.enonic.xp.app` plugin, not the project's own catalog.
- No `[plugins]` block — plugin versions stay inline as before.

## Catalog

```toml
[versions]
asset = "2.0.0-SNAPSHOT"
thymeleaf = "3.0.0-SNAPSHOT"

[libraries]
lib-asset = { module = "com.enonic.lib:lib-asset", version.ref = "asset" }
lib-thymeleaf = { module = "com.enonic.lib:lib-thymeleaf", version.ref = "thymeleaf" }
```

## build.gradle diff

```diff
-    include "com.enonic.lib:lib-thymeleaf:3.0.0-SNAPSHOT"
-    include "com.enonic.lib:lib-asset:2.0.0-SNAPSHOT"
+    include libs.lib.thymeleaf
+    include libs.lib.asset
```

## Test plan

- [x] `./gradlew dependencies --configuration runtimeClasspath` is byte-identical before vs. after (only the trailing `BUILD SUCCESSFUL in N` timing line differs).
- [x] `./gradlew build --refresh-dependencies` is green; webpack build + all 7 jest tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)